### PR TITLE
Patches following installation instructions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,6 @@
         ]
     },
     "scripts": {
-        "post-install-cmd": [
-            "php artisan clear-compiled",
-            "php artisan optimize"
-        ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
             "php artisan optimize"
         ],

--- a/database/seeds/ClientsTableSeeder.php
+++ b/database/seeds/ClientsTableSeeder.php
@@ -9,16 +9,20 @@ class ClientsTableSeeder extends Seeder {
 	{
 		$faker = Faker::create();
 
-		DB::table('clients')->truncate();		
+		DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+		DB::table('clients')->truncate();
 		DB::table('clients')->insert(
 		    array(
 		    	'name' 				=>	$faker->name,
-		    	'user_id' 			=> 	1, 
+		    	'user_id' 			=> 	1,
 		    	'phone_number'		=>	"1-55-555-555",
 		    	'point_of_contact' 	=> 	$faker->name,
 		    	'email'				=>	"test@test.com",
 		    	)
 		);
+
+		DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 	}
 
 }

--- a/database/seeds/ProjectsTableSeeder.php
+++ b/database/seeds/ProjectsTableSeeder.php
@@ -13,15 +13,19 @@ class ProjectsTableSeeder extends Seeder {
 	{
 		$faker = Faker::create();
 
+		DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
 		DB::table('projects')->truncate();
-		
+
 		DB::table('projects')->insert(
 		    array(
 		    	'name' 				=>	"First Project",
-		    	'user_id' 			=> 	1, 
+		    	'user_id' 			=> 	1,
 		    	'client_id'			=>	1,
 		    	)
 		);
+
+		DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 	}
 
 }

--- a/database/seeds/TasksTableSeeder.php
+++ b/database/seeds/TasksTableSeeder.php
@@ -9,15 +9,19 @@ class TasksTableSeeder extends Seeder {
 	{
 		$faker = Faker::create();
 
-		DB::table('tasks')->truncate();		
+		DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+		DB::table('tasks')->truncate();
 		DB::table('tasks')->insert(
 		    array(
 		    	'user_id' 			=>	1,
-		    	'project_id' 		=>	1, 
+		    	'project_id' 		=>	1,
 		    	'name'				=>	"First Task",
 		    	'state' 			=> 	"incomplete",
 		    	'weight'			=>	2,
 		    	)
 		);
+
+		DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 	}
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -9,14 +9,18 @@ class UsersTableSeeder extends Seeder {
 	{
 		$faker = Faker::create();
 
-		DB::table('users')->truncate();		
+		DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+		DB::table('users')->truncate();
 		DB::table('users')->insert(
 		    array(
 		    	'full_name' 		=>	$faker->name,
-		    	'email' 			=> 	'test@ribbbon.com', 
+		    	'email' 			=> 	'test@ribbbon.com',
 		    	'password'			=>	Hash::make('secret'),
 		    	'tasks_created' 	=> 	1,
 		    	)
 		);
+
+		DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 	}
 }


### PR DESCRIPTION
Following the installation instructions has presented some errors on my installation. These patches are updates to resolve the errors.

Updates to overcome errors with composer install and the database seeder (which had integrity constraint violation errors) and included the seeder class (`use Illuminate\Database\Seeder;`). 

Patches to composer.json to allow `composer install` to work, as the script calls generate an error.